### PR TITLE
Fix deprecation warnings after upgrade to React 15.5.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "15.x",
-    "react-dom": "15.x"
+    "react-dom": "15.x",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",
@@ -48,8 +49,5 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.16.2"
-  },
-  "dependencies": {
-    "prop-types": "^15.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.16.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const DEFAULT_LISTEN_INTERVAL = 10000;
 
@@ -110,23 +111,23 @@ class ReactAudioPlayer extends Component {
 }
 
 ReactAudioPlayer.propTypes = {
-  autoPlay: React.PropTypes.bool,
-  children: React.PropTypes.element,
-  className: React.PropTypes.string,
-  listenInterval: React.PropTypes.number,
-  onAbort: React.PropTypes.func,
-  onCanPlay: React.PropTypes.func,
-  onCanPlayThrough: React.PropTypes.func,
-  onEnded: React.PropTypes.func,
-  onError: React.PropTypes.func,
-  onListen: React.PropTypes.func,
-  onPause: React.PropTypes.func,
-  onPlay: React.PropTypes.func,
-  onSeeked: React.PropTypes.func,
-  preload: React.PropTypes.string,
-  src: React.PropTypes.string,
-  controls: React.PropTypes.bool,
-  style: React.PropTypes.object,
+  autoPlay: PropTypes.bool,
+  children: PropTypes.element,
+  className: PropTypes.string,
+  listenInterval: PropTypes.number,
+  onAbort: PropTypes.func,
+  onCanPlay: PropTypes.func,
+  onCanPlayThrough: PropTypes.func,
+  onEnded: PropTypes.func,
+  onError: PropTypes.func,
+  onListen: PropTypes.func,
+  onPause: PropTypes.func,
+  onPlay: PropTypes.func,
+  onSeeked: PropTypes.func,
+  preload: PropTypes.string,
+  src: PropTypes.string,
+  controls: PropTypes.bool,
+  style: PropTypes.object,
 };
 
 export default ReactAudioPlayer;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -102,6 +102,7 @@ class ReactAudioPlayer extends Component {
         ref={(ref) => { this.audioEl = ref; }}
         onPlay={this.onPlay}
         loop={this.props.loop}
+        {...this.props}
       >
         {incompatibilityMessage}
       </audio>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -102,7 +102,6 @@ class ReactAudioPlayer extends Component {
         ref={(ref) => { this.audioEl = ref; }}
         onPlay={this.onPlay}
         loop={this.props.loop}
-        {...this.props}
       >
         {incompatibilityMessage}
       </audio>


### PR DESCRIPTION
After upgrading react to v. 15.5.*, there are two warnings related to react-audio-player:

<img width="1435" alt="screen shot 2017-04-23 at 14 46 17" src="https://cloud.githubusercontent.com/assets/7155799/25313686/c8d89796-2833-11e7-84af-51d211e8b61a.png">

This pull request solves #31. 
