### PR TITLE
Explicit props

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,37 @@ This is a light React wrapper around the HTML5 audio tag.  It provides the abili
     <ReactAudioPlayer
       src="my_audio_file.ogg"
       autoPlay
+      controls
     />
 
 ### Example
 
 See the example directory for a basic working example of using this.  You can run it with the command `npm run example`.
 
-## API
+## Props
+
+### Props - Native/React Attributes
+See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for detailed explanations of these attributes.
+
+#### autoPlay {Bool} [false]
+
+#### children {Element} [null]
+
+#### className {String} ['']
+
+#### controls {Bool} [false]
+
+#### loop {Bool} [false]
+
+#### muted {Bool} [false]
+
+#### preload {String} ['metadata']
+
+#### src {String} ['']
+
+#### style {Object} [{}]
+
+### Props - Events
 
 #### listenInterval {Number} [10000]
 Indicates how often to call the `onListened` prop during playback, in milliseconds.
@@ -28,6 +52,9 @@ Called when unloading the audio player, like when switching to a different src f
 
 #### onCanPlay {Function}
 Called when enough of the file has been downloaded to be able to start playing.  Passed the event.
+
+#### onCanPlayThrough {Function}
+Called when enough of the file has been downloaded to play through the entire file.  Passed the event.
 
 #### onEnded {Function}
 Called when playback has finished to the end of the file. Passed the event.
@@ -47,16 +74,13 @@ Called when the user taps play.  Passed the event.
 #### onSeeked {Function}
 Called when the user drags the time indicator to a new time. Passed the event.
 
-#### preload {String}
-Indicates whether the browser should preload the media. See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for details.
-
 ## Advanced Usage
 
 ### Access to the audio element
 You can get direct access to the underlying audio element.  First get a ref to ReactAudioPlayer:
 
     <ReactAudioPlayer
-      ref={c => this.rap = c }
+      ref={(element) => { this.rap = element; }}
     />
 
 Then you can access the audio element like this:

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ You can get direct access to the underlying audio element.  First get a ref to R
 Then you can access the audio element like this:
 
     this.rap.audioEl
+
+This is especially useful if you need access to read-only attributes of the audio tag such as `buffered` and `played`.  See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for more on these attributes.

--- a/example/js/main.jsx
+++ b/example/js/main.jsx
@@ -5,6 +5,7 @@ import ReactAudioPlayer from '../../src/index';
 ReactDOM.render(
   <ReactAudioPlayer
     src="/files/George_Gershwin_playing_Rhapsody_in_Blue.ogg"
+    controls
   />,
   document.querySelector('.app')
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -95,6 +95,7 @@ class ReactAudioPlayer extends Component {
         className={`react-audio-player ${this.props.className}`}
         controls={controls}
         loop={this.props.loop}
+        muted={this.props.muted}
         onPlay={this.onPlay}
         preload={this.props.preload}
         ref={(ref) => { this.audioEl = ref; }}
@@ -114,6 +115,7 @@ ReactAudioPlayer.defaultProps = {
   controls: false,
   listenInterval: 10000,
   loop: false,
+  muted: false,
   onAbort: () => {},
   onCanPlay: () => {},
   onCanPlayThrough: () => {},
@@ -135,6 +137,7 @@ ReactAudioPlayer.propTypes = {
   controls: PropTypes.bool,
   listenInterval: PropTypes.number,
   loop: PropTypes.bool,
+  muted: PropTypes.bool,
   onAbort: PropTypes.func,
   onCanPlay: PropTypes.func,
   onCanPlayThrough: PropTypes.func,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,54 +1,52 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-const DEFAULT_LISTEN_INTERVAL = 10000;
-
 class ReactAudioPlayer extends Component {
   componentDidMount() {
     const audio = this.audioEl;
 
     audio.addEventListener('error', (e) => {
-      this.props.onError && this.props.onError(e);
+      this.props.onError(e);
     });
 
     // When enough of the file has downloaded to start playing
     audio.addEventListener('canplay', (e) => {
-      this.props.onCanPlay && this.props.onCanPlay(e);
+      this.props.onCanPlay(e);
     });
 
     // When enough of the file has downloaded to play the entire file
     audio.addEventListener('canplaythrough', (e) => {
-      this.props.onCanPlayThrough && this.props.onCanPlayThrough(e);
+      this.props.onCanPlayThrough(e);
     });
 
     // When audio play starts
     audio.addEventListener('play', (e) => {
       this.setListenTrack();
-      this.props.onPlay && this.props.onPlay(e);
+      this.props.onPlay(e);
     });
 
     // When unloading the audio player (switching to another src)
     audio.addEventListener('abort', (e) => {
       this.clearListenTrack();
-      this.props.onAbort && this.props.onAbort(e);
+      this.props.onAbort(e);
     });
 
     // When the file has finished playing to the end
     audio.addEventListener('ended', (e) => {
       this.clearListenTrack();
-      this.props.onEnded && this.props.onEnded(e);
+      this.props.onEnded(e);
     });
 
     // When the user pauses playback
     audio.addEventListener('pause', (e) => {
       this.clearListenTrack();
-      this.props.onPause && this.props.onPause(e);
+      this.props.onPause(e);
     });
 
     // When the user drags the time indicator to a new time
     audio.addEventListener('seeked', (e) => {
       this.clearListenTrack();
-      this.props.onSeeked && this.props.onSeeked(e);
+      this.props.onSeeked(e);
     });
   }
 
@@ -66,9 +64,9 @@ class ReactAudioPlayer extends Component {
    */
   setListenTrack() {
     if (!this.listenTracker) {
-      const listenInterval = this.props.listenInterval || DEFAULT_LISTEN_INTERVAL;
+      const listenInterval = this.props.listenInterval;
       this.listenTracker = setInterval(() => {
-        this.props.onListen && this.props.onListen(this.audioEl.currentTime);
+        this.props.onListen(this.audioEl.currentTime);
       }, listenInterval);
     }
   }
@@ -93,16 +91,15 @@ class ReactAudioPlayer extends Component {
 
     return (
       <audio
-        className={`react-audio-player ${this.props.className || ''}`}
-        style={this.props.style}
-        src={this.props.src || ''}
         autoPlay={this.props.autoPlay}
-        preload={this.props.preload}
+        className={`react-audio-player ${this.props.className}`}
         controls={controls}
-        ref={(ref) => { this.audioEl = ref; }}
-        onPlay={this.onPlay}
         loop={this.props.loop}
-        {...this.props}
+        onPlay={this.onPlay}
+        preload={this.props.preload}
+        ref={(ref) => { this.audioEl = ref; }}
+        src={this.props.src}
+        style={this.props.style}
       >
         {incompatibilityMessage}
       </audio>
@@ -110,11 +107,34 @@ class ReactAudioPlayer extends Component {
   }
 }
 
+ReactAudioPlayer.defaultProps = {
+  autoPlay: false,
+  children: null,
+  className: '',
+  controls: false,
+  listenInterval: 10000,
+  loop: false,
+  onAbort: () => {},
+  onCanPlay: () => {},
+  onCanPlayThrough: () => {},
+  onEnded: () => {},
+  onError: () => {},
+  onListen: () => {},
+  onPause: () => {},
+  onPlay: () => {},
+  onSeeked: () => {},
+  preload: 'metadata',
+  src: null,
+  style: {},
+};
+
 ReactAudioPlayer.propTypes = {
   autoPlay: PropTypes.bool,
   children: PropTypes.element,
   className: PropTypes.string,
+  controls: PropTypes.bool,
   listenInterval: PropTypes.number,
+  loop: PropTypes.bool,
   onAbort: PropTypes.func,
   onCanPlay: PropTypes.func,
   onCanPlayThrough: PropTypes.func,
@@ -124,10 +144,9 @@ ReactAudioPlayer.propTypes = {
   onPause: PropTypes.func,
   onPlay: PropTypes.func,
   onSeeked: PropTypes.func,
-  preload: PropTypes.string,
-  src: PropTypes.string,
-  controls: PropTypes.bool,
-  style: PropTypes.object,
+  preload: PropTypes.oneOf(['', 'none', 'metadata', 'auto']),
+  src: PropTypes.string, // Not required b/c can use <source>
+  style: PropTypes.objectOf(PropTypes.string),
 };
 
 export default ReactAudioPlayer;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -50,15 +50,6 @@ class ReactAudioPlayer extends Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.selectedPlayerEvent) {
-      const audio = this.audioEl;
-
-      audio.currentTime = nextProps.selectedPlayerEvent.playTime;
-      audio.play();
-    }
-  }
-
   /**
    * Set an interval to call props.onListen every props.listenInterval time period
    */


### PR DESCRIPTION
Include all attributes for the native audio tag as explicitly supported props.  This fixes the problem with `{...this.props}` from https://github.com/justinmc/react-audio-player/pull/30.  If any future attributes are missing support here, support should be explicitly added instead of adding generic props to the audio tag.