### PR TITLE
feat(controlsList): passing through Chrome's controlsList attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/H
 
 #### controls {Bool} [false]
 
+#### controlsList {String} ['']
+
 #### loop {Bool} [false]
 
 #### muted {Bool} [false]

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -88,6 +88,7 @@ class ReactAudioPlayer extends Component {
         autoPlay={this.props.autoPlay}
         className={`react-audio-player ${this.props.className}`}
         controls={controls}
+        controlsList={this.props.controlsList}
         loop={this.props.loop}
         muted={this.props.muted}
         onPlay={this.onPlay}
@@ -108,6 +109,7 @@ ReactAudioPlayer.defaultProps = {
   children: null,
   className: '',
   controls: false,
+  controlsList: '',
   listenInterval: 10000,
   loop: false,
   muted: false,
@@ -131,6 +133,7 @@ ReactAudioPlayer.propTypes = {
   children: PropTypes.element,
   className: PropTypes.string,
   controls: PropTypes.bool,
+  controlsList: PropTypes.string,
   listenInterval: PropTypes.number,
   loop: PropTypes.bool,
   muted: PropTypes.bool,


### PR DESCRIPTION
Google Chrome allows an attribute 'controlsList', which allows you to
blacklist certain controls, like the download button. This change passes
the attribute through so that it can be used with ReactAudioPlayer.
https://googlechrome.github.io/samples/media/controlslist.html