### PR TITLE
feat(controlsList): passing through Chrome's controlsList attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/H
 
 #### controls {Bool} [false]
 
+#### controlsList {String} ['']
+_For Chrome 58+. Only available in React 15.6.2+_
+
 #### loop {Bool} [false]
 
 #### muted {Bool} [false]

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "react": "^15.0.2",
-    "react-addons-test-utils": "^15.0.2",
-    "react-dom": "^15.0.2",
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.6.2",
+    "react-dom": "^15.6.2",
     "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.16.2"

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -38,7 +38,7 @@ describe('ReactAudioPlayer', function() {
     );
 
     const instanceEl = ReactDOM.findDOMNode(instance);
-    
+
     expect(instanceEl.getAttribute("title")).toBe("Turkish march");
   })
 
@@ -49,6 +49,7 @@ describe('ReactAudioPlayer', function() {
         loop="loop"
         name="custom-name"
         data-id="custom-data"
+        controlsList="nodownload"
       />
     );
 
@@ -56,7 +57,8 @@ describe('ReactAudioPlayer', function() {
 
     expect(props).toContain('name');
     expect(props).toContain('data-id');
-  })
+    expect(props).toContain('controlsList');
+  });
 
   describe('when can play', function() {
     it('calls onCanPlay', function(done) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -86,6 +86,12 @@ class ReactAudioPlayer extends Component {
     // Set lockscreen / process audio title on devices
     const title = this.props.title ? this.props.title : this.props.src;
 
+    // Some props should only be added if specified
+    const conditionalProps = {};
+    if (this.props.controlsList) {
+      conditionalProps.controlsList = this.props.controlsList;
+    }
+
     return (
       <audio
         autoPlay={this.props.autoPlay}
@@ -99,6 +105,7 @@ class ReactAudioPlayer extends Component {
         src={this.props.src}
         style={this.props.style}
         title={title}
+        {...conditionalProps}
       >
         {incompatibilityMessage}
       </audio>
@@ -111,6 +118,7 @@ ReactAudioPlayer.defaultProps = {
   children: null,
   className: '',
   controls: false,
+  controlsList: '',
   listenInterval: 10000,
   loop: false,
   muted: false,
@@ -135,6 +143,7 @@ ReactAudioPlayer.propTypes = {
   children: PropTypes.element,
   className: PropTypes.string,
   controls: PropTypes.bool,
+  controlsList: PropTypes.string,
   listenInterval: PropTypes.number,
   loop: PropTypes.bool,
   muted: PropTypes.bool,


### PR DESCRIPTION
Google Chrome allows an attribute 'controlsList', which allows you to
blacklist certain controls, like the download button. This change passes
the attribute through so that it can be used with ReactAudioPlayer.
https://googlechrome.github.io/samples/media/controlslist.html

Originally filed in #35, but I closed that one since React didn't support the attribute.
However, [support was added in 15.6.2](https://github.com/facebook/react/issues/9594), so this should be good now.