### PR TITLE
"prop-types" not defined as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "react-dom": "15.x",
     "prop-types": "^15.5.8"
   },
+  "dependencies": {
+    "react": "^15.6.2",
+    "prop-types": "^15.5.8"
+  },
   "devDependencies": {
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",
@@ -43,7 +47,6 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.7",
     "karma-webpack": "^1.7.0",
-    "react": "^15.6.2",
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-hot-loader": "^3.0.0-beta.6",


### PR DESCRIPTION
Just got the following error from webpack, trying to build `react-audio-player` into a project:
```
    ERROR in ./~/react-audio-player/dist/bundle.js
    Module not found: Error: Cannot resolve module 'prop-types' in /home/ubuntu/my-project/node_modules/react-audio-player/dist
     @ ./~/react-audio-player/dist/bundle.js 1:4276-4297
```

This should fix it – `prop-types` needs to be listed in `dependencies` as well as in `peerDependencies`.