### PR TITLE
Cross Origin Should Be Omittable

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -141,7 +141,7 @@ ReactAudioPlayer.defaultProps = {
   className: '',
   controls: false,
   controlsList: '',
-  crossOrigin:'',
+  crossOrigin: null,
   id: '',
   listenInterval: 10000,
   loop: false,


### PR DESCRIPTION
Closes https://github.com/justinmc/react-audio-player/issues/48

@dmcmorris with this change, not passing the `crossOrigin` prop will result in an audio tag with no `crossorigin` attribute at all.  Let me know if that fixes your use case.