### PR TITLE
update readme to include useRef and examples of custom pause/play buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Then you can access the audio element like this:
 
 This is especially useful if you need access to read-only attributes of the audio tag such as `buffered` and `played`. See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for more on these attributes.
 
-You can also use this to create custom controls such as a play or pause button, like this:
+You can also use this to create custom controls such as play, pause, or stop buttons, like this:
 
     const [isPlaying, setIsPlaying] = useState(autoPlay)
 
@@ -92,6 +92,14 @@ You can also use this to create custom controls such as a play or pause button, 
         setIsPlaying(false)
       }
     }
+    
+    const stopAudio = () => {
+      if (audioPlayerRef.current) {
+        audioPlayerRef.current.audioEl.current?.pause()
+        audioPlayerRef.current.audioEl.current.currentTime = 0
+        setIsPlaying(false)
+      }
+    }
 
     return (
       <div>
@@ -99,7 +107,8 @@ You can also use this to create custom controls such as a play or pause button, 
           src={url}
           ref={audioPlayerRef}
         />
-        <button onClick={playAudio}/>
-        <button onClick={pauseAudio}/>
+        <button onClick={playAudio}>Play</button>
+        <button onClick={pauseAudio}>Pause</button>
+        <button onClick={stopAudio}>Stop</button>
       </div>
     )

--- a/README.md
+++ b/README.md
@@ -62,14 +62,44 @@ Prop | Type | Description
 ## Advanced Usage
 
 ### Access to the audio element
-You can get direct access to the underlying audio element.  First get a ref to ReactAudioPlayer:
+You can get direct access to the underlying audio element. First get a ref to ReactAudioPlayer with useRef():
 
-    <ReactAudioPlayer
-      ref={(element) => { this.rap = element; }}
-    />
+    const audioPlayerRef = useRef<ReactAudioPlayer>(null)
 
 Then you can access the audio element like this:
 
-    this.rap.audioEl
+    <ReactAudioPlayer
+      src={url}
+      ref={audioPlayerRef}
+    />
 
-This is especially useful if you need access to read-only attributes of the audio tag such as `buffered` and `played`.  See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for more on these attributes.
+This is especially useful if you need access to read-only attributes of the audio tag such as `buffered` and `played`. See the [audio tag documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio) for more on these attributes.
+
+You can also use this to create custom controls such as a play or pause button, like this:
+
+    const [isPlaying, setIsPlaying] = useState(autoPlay)
+
+    const playAudio = () => {
+      if (audioPlayerRef.current) {
+        audioPlayerRef.current.audioEl.current?.play()
+        setIsPlaying(true)
+      }
+    }
+
+    const pauseAudio = () => {
+      if (audioPlayerRef.current) {
+        audioPlayerRef.current.audioEl.current?.pause()
+        setIsPlaying(false)
+      }
+    }
+
+    return (
+      <div>
+        <ReactAudioPlayer
+          src={url}
+          ref={audioPlayerRef}
+        />
+        <button onClick={playAudio}/>
+        <button onClick={pauseAudio}/>
+      </div>
+    )


### PR DESCRIPTION
I've updated the Readme to replace the usage of `this.rap.audioEl` with an implementation that uses `useRef` instead. I've also added an example of how to use the ref to add custom play, pause, and stop buttons since how to do that seems to be a common question that people have.

Example (imagine music playing):
https://github.com/justinmc/react-audio-player/assets/59536294/e994d233-73aa-4093-8241-aaf30b153fcd

